### PR TITLE
fix wolfpack model require

### DIFF
--- a/lib/wolfpack.js
+++ b/lib/wolfpack.js
@@ -24,7 +24,7 @@ function wolfpack(model_path) {
   if (typeof model_path === 'string') {
     // Load the model
     try {
-      model = require(model_path);
+      model = require(path.join(process.cwd(), model_path));
     } catch (e) {
       throw new Error('WOLFPACK: Cannot load model: ' + e.message);
     }


### PR DESCRIPTION
When I create a file "test.js" in my root project folder (using Sails) with following content: 

<pre>
var wolfpack = require('wolfpack'),
      myModel = wolfpack('/api/models/MyModel');
</pre>

WolfPack cannot find MyModel file because it expects that file in wolfpack\lib\node_modules\api\models\MyModel

<pre>
try {
      model = require(model_path);
    }
</pre>


process.cwd() will get the current require function caller, make wolfpack search the right dir.
