### PR TITLE
npm 3 compatibility - looking in base node_modules directory for dependencies

### DIFF
--- a/lib/wolfpack.js
+++ b/lib/wolfpack.js
@@ -15,7 +15,7 @@ try {
   try {
     // Try loading waterline from node_modules directly (if on npm 3> dependencies are install in top level node_modules)
     Waterline = require(__dirname + '/../../waterline');
-  } catch {
+  } catch (e) {
     // If it cannot be loaded, then load wolfpack's waterline
     Waterline = require('waterline');
   }
@@ -126,7 +126,7 @@ function wolfpack(model_path, pk_type) {
   var Schema = null;
   try {
     Schema = require('waterline/node_modules/waterline-schema');
-  } catch {
+  } catch (e) {
     // Try loading waterline from node_modules directly (if on npm 3> dependencies are install in top level node_modules)
     Schema = require('waterline-schema/lib/waterline-schema');
   }

--- a/lib/wolfpack.js
+++ b/lib/wolfpack.js
@@ -12,8 +12,13 @@ try {
   // Try loading waterline from sails first rather than from package
   Waterline = require(__dirname + '/../../sails/node_modules/waterline');
 } catch (e) {
-  // If it cannot be loaded, then load wolfpack's waterline
-  Waterline = require('waterline');
+  try {
+    // Try loading waterline from node_modules directly (if on npm 3> dependencies are install in top level node_modules)
+    Waterline = require(__dirname + '/../../waterline');
+  } catch {
+    // If it cannot be loaded, then load wolfpack's waterline
+    Waterline = require('waterline');
+  }
 }
 
 var sinon = require('sinon'),
@@ -118,7 +123,13 @@ function wolfpack(model_path, pk_type) {
   
   var CollectionLoader = require('waterline/lib/waterline/collection/loader');
   var Connections = require('waterline/lib/waterline/connections');
-  var Schema = require('waterline/node_modules/waterline-schema');
+  var Schema = null;
+  try {
+    Schema = require('waterline/node_modules/waterline-schema');
+  } catch {
+    // Try loading waterline from node_modules directly (if on npm 3> dependencies are install in top level node_modules)
+    Schema = require('waterline-schema/lib/waterline-schema');
+  }
   
   var connections = new Connections(config.adapters, config.connections);
   var loader = new CollectionLoader(Class, connections, {});


### PR DESCRIPTION
I'm running npm 3 - wolfpack cannot find waterline-schema as it's installed directly in node_modules/waterline-schema, not nested within sails/node_modules/waterline/node_modules/waterline-schema.

This change should support existing npm installs and npm 3+ by looking in different directories for dependencies.
